### PR TITLE
Simplify lyrics DOM structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,15 @@ Customize your own styles by utilizing the CSS classes provided below.
 
 ```html
 <span class="lyrics-line" data-lyid="36" data-time="84160">
-    <span class="lyrics-timestamp" data-lyid="36" data-time="84160">01:24</span>
-    <span class="lyrics-text">
-        <p>Happy birthday.</p>
-    </span>
+	<span class="lyrics-timestamp" data-lyid="36" data-time="84160">01:24</span>
+	<p>Happy birthday.</p>
 </span>
 ```
 
--   `lyrics-wrapper`: the entire lyrics line.
--   `lyrics-timestamp`: timestamp of the lyrics.
--   `lyrics-text`: text content of the lyrics.
--   `lyrics-highlighted`: mark the current highlighted lyrics.
+-   `.lyrics-line`: the entire lyrics line.
+-   `.lyrics-line .lyrics-timestamp`: timestamp of the lyrics.
+-   `.lyrics-line p`: text content of the lyrics.
+-   `.lyrics-highlighted`: mark the current highlighted lyrics.
 
 ---
 

--- a/src/LyricsMarkdownRender.ts
+++ b/src/LyricsMarkdownRender.ts
@@ -358,8 +358,6 @@ export default class LyricsMarkdownRender extends MarkdownRenderChild {
                         lineEl.dataset.lyid = `${index}`
                         const timeEl = lineEl.createSpan()
                         timeEl.setText(lrc.timestr || '')
-                        const textEl = lineEl.createSpan()
-                        textEl.className = 'lyrics-text'
                         timeEl.className = 'lyrics-timestamp'
                         timeEl.dataset.lyid = `${index}`
                         if (lrc.timestamp) {
@@ -370,13 +368,11 @@ export default class LyricsMarkdownRender extends MarkdownRenderChild {
                         await MarkdownRenderer.render(
                             this.app,
                             lrc.text,
-                            textEl,
+                            lineEl,
                             this.path,
                             this,
                         )
-                        lineEl.append(textEl)
                     }
-
                     return lineEl
                 }),
             )

--- a/styles.css
+++ b/styles.css
@@ -19,13 +19,9 @@ If your plugin does not need CSS, delete this file.
     padding: 5px 0;
 }
 
-.lyrics-text {
+.lyrics-line p {
     flex: 1;
     padding: 5px;
-}
-
-.lyrics-text p {
-    padding: 0;
     margin: 0;
 }
 


### PR DESCRIPTION
Removing the unnecessary '.lyrics-text' element could simplify the DOM manipulation
